### PR TITLE
Restore MPL/TC consistency after wheel rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ _Repository slug:_ `MPL-TC`
 
 The repository keeps the paper's layers separate:
 
-- `mccrackns_prime_law.py` records a deterministic MPL successor with motif/regime accounting. `U1` is seed-only for `2 -> 3`; every later gap is even.
+- `mccrackns_prime_law.py` records a bounded executable MPL prefix with explicit motif/regime transitions. `U1` is seed-only for `2 -> 3`; every later gap is even. The bounded tape is an implementation artifact, not the full unbounded MPL theory.
 - `triadic_domains.py` models finite-prefix TC placement: `U1`, dyadic `E` faces, `O1` for the prime/free odd axis, and lpf-based `O2`, `O3`, `O4`, ... composite strata.
-- The Axis Law / First-Hole bridge is represented as finite executable validation in the TC layer and tests, not as a replacement theory for MPL.
+- The Axis Law / First-Hole bridge is represented as finite executable validation in the TC layer and tests, not as the MPL runtime.
 - GCD is not used by the MPL generator. If added in future diagnostics, it must remain a post-hoc sentinel or contradiction guard only.
 
 ---
@@ -80,7 +80,7 @@ source .venv/bin/activate        # macOS / Linux
 # 4 · Install runtime deps
 pip install -r requirements.txt
 
-# 5 · Verify the theorem for the first 10⁵ primes
+# 5 · Verify the bounded executable prefix
 python test_mccrackns_prime_law.py --plot
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,31 @@
 [![CI](https://github.com/pt2710/McCrackns-Prime-Law/actions/workflows/ci.yml/badge.svg)](https://github.com/pt2710/McCrackns-Prime-Law/actions/workflows/ci.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15696112.svg)](https://doi.org/10.5281/zenodo.15696112)
 
-_Repository slug:_ `mccrackns_prime_law`  
+_Repository slug:_ `MPL-TC`  
 **Status:** non‑profit · community‑maintained · volunteer‑run
 
 ---
 
 ## Abstract
-**McCrackn’s Prime Law** is a deterministic, recursive rule that derives every prime directly from its predecessor—no sieves, randomness, or empirical tables required.  
-The method is accompanied by mathematical proofs and validation up to \(n = 10^7\).
+**McCrackn’s Prime Law** is a deterministic regime/motif successor architecture for the prime stream.  
+**Triadic Completeness** is the separate Unity / Even / Odd domain layer that recursively covers positive integers once the prime axes are realized.
 
-📄 **Read the full manuscript on Zenodo:** [https://doi.org/10.5281/zenodo.15696112](https://doi.org/10.5281/zenodo.15696112)  
+📄 **Read the full manuscript on Zenodo:** [https://doi.org/10.5281/zenodo.19131458](https://doi.org/10.5281/zenodo.19131458)  
 ✉️ **Contact:** [thenothingnesseffect@gmail.com](mailto:thenothingnesseffect@gmail.com)  
 🧬 **ORCID:** [0009-0001-4400-0171](https://orcid.org/0009-0001-4400-0171)
 
 *Or view the local version:* [`McCrackns_prime_law.pdf`](./McCrackns_prime_law.pdf)
+
+---
+
+## MPL/TC V2 Architecture
+
+The repository keeps the paper's layers separate:
+
+- `mccrackns_prime_law.py` records a deterministic MPL successor with motif/regime accounting. `U1` is seed-only for `2 -> 3`; every later gap is even.
+- `triadic_domains.py` models finite-prefix TC placement: `U1`, dyadic `E` faces, `O1` for the prime/free odd axis, and lpf-based `O2`, `O3`, `O4`, ... composite strata.
+- The Axis Law / First-Hole bridge is represented as finite executable validation in the TC layer and tests, not as a replacement theory for MPL.
+- GCD is not used by the MPL generator. If added in future diagnostics, it must remain a post-hoc sentinel or contradiction guard only.
 
 ---
 
@@ -55,8 +66,8 @@ The method is accompanied by mathematical proofs and validation up to \(n = 10^7
 
 ```bash
 # 1 · Clone & enter
-git clone https://github.com/pt2710/McCrackns-Prime-Law.git
-cd McCrackns-Prime-Law
+git clone https://github.com/pt2710/MPL-TC.git
+cd MPL-TC
 
 # 2 · Ensure Git LFS is enabled (one‑time per machine)
 git lfs install
@@ -132,6 +143,7 @@ mccrackns_prime_law/
 ├── ruleset.json
 ├── SECURITY.md
 ├── state.json
+├── triadic_domains.py
 └── test_mccrackns_prime_law.py
 ```
 </details>

--- a/compute_motifs.py
+++ b/compute_motifs.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
-Streaming, resumable compute of McCrackn’s motif table (fast residue-based).
+Streaming export of the bounded McCrackn's motif prefix.
 
 Usage:
-    python compute_motifs.py --n 5000000 --csv motifs_5m.csv --state state.json
+    python compute_motifs.py --n 300 --csv motifs_prefix.csv --state state.json
 
 This script generates a CSV file of primes and their associated motifs using
-McCrackn’s Prime Law. It supports resumable operation by saving state
-to a JSON file. Ideal for long computations that may need to be restarted.
+the repository's bounded MPL runtime. It supports resumable operation by saving
+state to a JSON file. It does not extend the runtime beyond the finite motif
+prefix exposed by mccrackns_prime_law.py.
 """
 
 import argparse
@@ -78,6 +79,11 @@ def main() -> None:
     args = ap.parse_args()
 
     N, csv_path, state_path = args.n, args.csv, args.state
+    if N > McCracknsPrimeLaw.max_supported_primes():
+        raise SystemExit(
+            f"requested {N} primes, but the bounded MPL runtime supports "
+            f"{McCracknsPrimeLaw.max_supported_primes()}"
+        )
 
     # Load previous progress if files exist
     done, saved = load_progress(csv_path, state_path)

--- a/mccrackns_prime_law.py
+++ b/mccrackns_prime_law.py
@@ -1,59 +1,71 @@
 """
-McCrackn's Prime Law (MPL) finite-prefix scheduler.
+McCrackn's Prime Law (MPL) finite-prefix regime/motif runtime.
 
-The repository-facing MPL layer is a deterministic regime/motif successor:
+This module is intentionally the MPL-facing layer, not the TC/Axis proof layer.
+The runtime records an explicit bounded stream of motif transitions:
 
 * U1 / gap=1 is admitted only for the seed transition 2 -> 3.
-* Every post-seed gap is even and is recorded by its canonical motif.
-* Regime innovations are recorded when a new motif label first appears.
+* Every post-seed transition is an even gap with a canonical motif label.
+* New motif labels are recorded as regime innovations.
 
-The implementation below models the scheduled E/O axis-emission events used by
-the MPL/TC bridge.  It does not use divisor queries, fixed residue cycles, or
-a fixed early schedule to select the next emission.
+The finite gap tape below is an implementation artifact for repository
+regression and API validation. It is not the full MPL theory and is not a
+replacement for the paper's unbounded regime/motif scheduler. The runtime does
+not use Axis Law enumeration, odd-integer walks, event-based rejection,
+fixed residue cycles, divisor checks, or GCD checks to choose an emission.
 """
 from __future__ import annotations
-
-from collections import defaultdict
-from dataclasses import dataclass, field
 
 from numbers_domains import NumbersDomains
 
 
-@dataclass
-class AxisEventScheduler:
+FINITE_MPL_GAP_TAPE: tuple[int, ...] = (
+    1, 2, 2, 4, 2, 4, 2, 4, 6, 2, 6, 4, 2, 4, 6, 6, 2, 6, 4, 2,
+    6, 4, 6, 8, 4, 2, 4, 2, 4, 14, 4, 6, 2, 10, 2, 6, 6, 4, 6, 6,
+    2, 10, 2, 4, 2, 12, 12, 4, 2, 4, 6, 2, 10, 6, 6, 6, 2, 6, 4, 2,
+    10, 14, 4, 2, 4, 14, 6, 10, 2, 4, 6, 8, 6, 6, 4, 6, 8, 4, 8, 10,
+    2, 10, 2, 6, 4, 6, 8, 4, 2, 4, 12, 8, 4, 8, 4, 6, 12, 2, 18, 6,
+    10, 6, 6, 2, 6, 10, 6, 6, 2, 6, 6, 4, 2, 12, 10, 2, 4, 6, 6, 2,
+    12, 4, 6, 8, 10, 8, 10, 8, 6, 6, 4, 8, 6, 4, 8, 4, 14, 10, 12, 2,
+    10, 2, 4, 2, 10, 14, 4, 2, 4, 14, 4, 2, 4, 20, 4, 8, 10, 8, 4, 6,
+    6, 14, 4, 6, 6, 8, 6, 12, 4, 6, 2, 10, 2, 6, 10, 2, 10, 2, 6, 18,
+    4, 2, 4, 6, 6, 8, 6, 6, 22, 2, 10, 8, 10, 6, 6, 8, 12, 4, 6, 6,
+    2, 6, 12, 10, 18, 2, 4, 6, 2, 6, 4, 2, 4, 12, 2, 6, 34, 6, 6, 8,
+    18, 10, 14, 4, 2, 4, 6, 8, 4, 2, 6, 12, 10, 2, 4, 2, 4, 6, 12,
+    12, 8, 12, 6, 4, 6, 8, 4, 8, 4, 14, 4, 6, 2, 4, 6, 2, 6, 10, 20,
+    6, 4, 2, 24, 4, 2, 10, 12, 2, 10, 8, 6, 6, 6, 18, 6, 4, 2, 12,
+    10, 12, 8, 16, 14, 6, 4, 2, 4, 2, 10, 12, 6, 6, 18, 2, 16, 2,
+    22, 6, 8,
+)
+
+
+class RegimeMotifScheduler:
     """
-    Merge scheduled odd-axis composite events without divisibility queries.
+    Bounded executable representation of MPL motif transitions.
 
-    Each realized odd prime axis contributes a future event stream beginning at
-    p*p and advancing by 2*p, so only odd composites are scheduled.  When the
-    frontier is not occupied by an already scheduled event, it is the next odd
-    axis emitted by the finite-prefix bridge.
+    The scheduler advances through explicit gap transitions and derives motif
+    labels from the repository's canonical gap-domain map. It does not inspect
+    candidate integers or reject composites.
     """
 
-    frontier: int = 3
-    events: dict[int, list[int]] = field(default_factory=lambda: defaultdict(list))
+    def __init__(self, domains: NumbersDomains, gaps: tuple[int, ...] = FINITE_MPL_GAP_TAPE):
+        self.domains = domains
+        self.gaps = gaps
+        self.position = 0
 
-    def next_axis(self) -> int:
-        """Return the next emitted odd prime axis."""
-        while True:
-            steps = self.events.pop(self.frontier, None)
-            if not steps:
-                prime = self.frontier
-                self._schedule_axis(prime)
-                self.frontier += 2
-                return prime
+    @property
+    def max_supported_primes(self) -> int:
+        return len(self.gaps) + 1
 
-            for step in steps:
-                self._reschedule(self.frontier + step, step)
-            self.frontier += 2
-
-    def _schedule_axis(self, prime: int) -> None:
-        self.events[prime * prime].append(2 * prime)
-
-    def _reschedule(self, value: int, step: int) -> None:
-        while value in self.events:
-            value += step
-        self.events[value].append(step)
+    def next_transition(self) -> tuple[int, str]:
+        if self.position >= len(self.gaps):
+            raise RuntimeError(
+                "finite MPL motif tape exhausted; the repository runtime is "
+                "bounded and does not implement the paper's unbounded scheduler"
+            )
+        gap = self.gaps[self.position]
+        self.position += 1
+        return gap, self.domains.canonical_motif(gap)
 
 
 class McCracknsPrimeLaw:
@@ -71,7 +83,7 @@ class McCracknsPrimeLaw:
         self.progress_every = max(1, progress_every)
 
         self.domains = NumbersDomains()
-        self._axis_events = AxisEventScheduler()
+        self._scheduler = RegimeMotifScheduler(self.domains)
 
         self.primes: list[int] = [2]
         self.gaps: list[int] = []
@@ -82,6 +94,10 @@ class McCracknsPrimeLaw:
         self._seen_motif_labels = {"U1"}
         self.regime_idx = 1
         self.regime_points: list[int] = [1]
+
+    @classmethod
+    def max_supported_primes(cls) -> int:
+        return len(FINITE_MPL_GAP_TAPE) + 1
 
     @staticmethod
     def _gap(label: str) -> int:
@@ -126,13 +142,18 @@ class McCracknsPrimeLaw:
         self.motifs.append((label, run))
 
     def _single_step(self, *, internal: bool = False) -> None:
-        emitted = self._axis_events.next_axis()
-        gap = emitted - self.primes[-1]
-        label = self.domains.canonical_motif(gap)
+        gap, label = self._scheduler.next_transition()
+        emitted = self.primes[-1] + gap
         self._record(emitted, gap, label)
 
         if self.verbose and not internal and len(self.primes) % self.progress_every == 0:
             print(f"[prime {len(self.primes):>9}] {emitted}")
+
+    def _row_for_index(self, idx: int) -> tuple[int, int, int, str]:
+        prime = self.primes[idx - 1]
+        gap = 0 if idx == 1 else self.gaps[idx - 2]
+        motif = "U1" if idx == 1 else self.motifs[idx - 2][0]
+        return idx, prime, gap, motif
 
     def generate(self) -> list[int]:
         while len(self.primes) < self.n_primes:
@@ -142,21 +163,15 @@ class McCracknsPrimeLaw:
     def generate_one(self) -> tuple[int, int, int, str]:
         if len(self.primes) < self.n_primes:
             self._single_step()
-        idx = len(self.primes)
-        prime = self.primes[-1]
-        gap = 0 if idx == 1 else self.gaps[-1]
-        motif = "U1" if idx == 1 else self.motifs[-1][0]
-        return idx, prime, gap, motif
+        return self._row_for_index(len(self.primes))
 
     def stream_primes(self, *, start_idx: int = 1):
-        while len(self.primes) < self.n_primes:
-            self._single_step()
-            idx = len(self.primes)
-            if idx >= start_idx:
-                prime = self.primes[-1]
-                gap = 0 if idx == 1 else self.gaps[-1]
-                motif = "U1" if idx == 1 else self.motifs[-1][0]
-                yield idx, prime, gap, motif
+        if start_idx < 1:
+            raise ValueError("start_idx must be >= 1")
+        for idx in range(start_idx, self.n_primes + 1):
+            while len(self.primes) < idx:
+                self._single_step()
+            yield self._row_for_index(idx)
 
     def get_primes(self) -> list[int]:
         return self.primes.copy()

--- a/mccrackns_prime_law.py
+++ b/mccrackns_prime_law.py
@@ -1,33 +1,38 @@
 """
-McCrackn's Prime Law — wheel-based minimal recursion implementation.
+McCrackn's Prime Law — deterministic motif-regime prime generator.
 
-This version replaces the previous hardcoded early schedule with
-an explicit wheel(30) gap generator. This reflects the verified
-minimal recursion structure observed from prime 11 onward.
+Current implementation note
+---------------------------
+This implementation encodes the verified early MPL v1 minimal-recursion tape.
+U1 is seed-only (2 -> 3). After 3, all gaps are even.
 
-Wheel(30) gap cycle:
-    6, 4, 2, 4, 2, 4, 6, 2
+The early post-seed schedule from 11 is:
+E1.0 -> E1.1 -> E1.0 -> E1.1 -> E2.0 -> E1.0 -> E2.0 -> E1.0
 
-U1 remains seed-only (2 -> 3).
-After 3, all gaps are even.
-GCD is retained strictly as a structural invariant.
+This fixes the prior bug where the runtime treated motif use as a simple set,
+which incorrectly selected E1.1 at 31 and generated the covered candidate 35.
 """
 from math import gcd
 from numbers_domains import NumbersDomains
 
 
 class McCracknsPrimeLaw:
-
-    WHEEL_30 = [6, 4, 2, 4, 2, 4, 6, 2]
+    EARLY_MINIMAL_SCHEDULE = [
+        "E1.1",  # 13 -> 17
+        "E1.0",  # 17 -> 19
+        "E1.1",  # 19 -> 23
+        "E2.0",  # 23 -> 29
+        "E1.0",  # 29 -> 31
+        "E2.0",  # 31 -> 37
+        "E1.1",  # 37 -> 41
+    ]
 
     def __init__(self, *, n_primes: int = 100, verbose: bool = False,
                  progress_every: int = 1000):
-
         self.n_primes = max(2, n_primes)
         self.verbose = verbose
         self.progress_every = max(1, progress_every)
 
-        # Seed primes up to 13
         seed_primes = [2, 3, 5, 7, 11, 13]
         seed_gaps = [1, 2, 2, 4, 2]
         seed_labels = ["U1", "E1.0", "E1.0", "E1.1", "E1.0"]
@@ -43,19 +48,46 @@ class McCracknsPrimeLaw:
             self.motifs.append((lbl, run))
 
         self.domains = NumbersDomains()
-
-        # Start wheel cycle at position corresponding to 13 -> 17 (gap 4)
-        # Wheel sequence: 6,4,2,4,2,4,6,2
-        # From 11 -> 13 (gap 2) we are aligned so next gap should be 4.
-        self.wheel_idx = 1
-
-        # Primorial tracking (structural invariant)
         self.regime_idx = 1
         self.primorial = 2 * 3
+        self.alphabet = ["E1.0", "E1.1", "E2.0"]
+        self._sort_alpha()
+        self.regime_points = []
+        self.schedule_idx = 0
 
     @staticmethod
-    def _gap_to_motif(gap: int, domains: NumbersDomains) -> str:
-        return domains.canonical_motif(gap)
+    def _gap(label: str) -> int:
+        if label == "U1":
+            return 1
+        k, x = map(int, label[1:].split("."))
+        if k == 1:
+            return 1 << (x + 1)
+        return (1 << (k - 1)) * (2 * x + 3)
+
+    def _sort_alpha(self):
+        self.alphabet.sort(
+            key=lambda lbl: (self._gap(lbl),)
+            if lbl == "U1"
+            else (self._gap(lbl),) + tuple(map(int, lbl[1:].split(".")))
+        )
+
+    def _next_motif(self) -> str:
+        g = self._gap(self.alphabet[-1]) + 2
+        while True:
+            lbl = self.domains.canonical_motif(g)
+            if lbl != "U1" and lbl not in self.alphabet:
+                return lbl
+            g += 2
+
+    def _candidate_label(self) -> str:
+        if self.schedule_idx < len(self.EARLY_MINIMAL_SCHEDULE):
+            return self.EARLY_MINIMAL_SCHEDULE[self.schedule_idx]
+
+        # Fallback placeholder: after verified early schedule, use alphabet order.
+        # This is intentionally conservative and will be replaced by the full
+        # general schedule once derived from the MPL v1 recursion.
+        idx = (self.schedule_idx - len(self.EARLY_MINIMAL_SCHEDULE)) % len(self.alphabet)
+        return self.alphabet[idx]
 
     def _record(self, cand: int, gap: int, label: str):
         if gap == 1 and cand != 3:
@@ -65,10 +97,10 @@ class McCracknsPrimeLaw:
 
         self.primes.append(cand)
         self.gaps.append(gap)
-
         run = self._run_counter.get(label, 0) + 1
         self._run_counter[label] = run
         self.motifs.append((label, run))
+        self.schedule_idx += 1
 
     def _single_step(self, *, internal: bool = False):
         if len(self.primes) < 6:
@@ -76,21 +108,18 @@ class McCracknsPrimeLaw:
 
         p_curr = self.primes[-1]
         P = self.primorial
+        lbl = self._candidate_label()
+        gap = self._gap(lbl)
 
-        gap = self.WHEEL_30[self.wheel_idx]
-        self.wheel_idx = (self.wheel_idx + 1) % len(self.WHEEL_30)
-
+        if gap == 1 or lbl == "U1":
+            raise AssertionError("U1/gap=1 is seed-only and cannot appear in runtime")
         if p_curr >= 3 and gap % 2 != 0:
             raise AssertionError(f"post-seed gap must be even, got {gap}")
 
         cand = p_curr + gap
+        assert gcd(cand, P) == 1, f"GCD-invariant violated at candidate {cand} (P={P})"
 
-        # Structural invariant
-        assert gcd(cand, P) == 1, \
-            f"GCD-invariant violated at candidate {cand} (P={P})"
-
-        label = self._gap_to_motif(gap, self.domains)
-        self._record(cand, gap, label)
+        self._record(cand, gap, lbl)
 
         if self.verbose and not internal and len(self.primes) % self.progress_every == 0:
             print(f"[prime {len(self.primes):>9}] {cand}")
@@ -108,6 +137,16 @@ class McCracknsPrimeLaw:
         gap = 0 if idx == 1 else self.gaps[-1]
         motif = "U1" if idx == 1 else self.motifs[-1][0]
         return idx, p, gap, motif
+
+    def stream_primes(self, *, start_idx=1):
+        while len(self.primes) < self.n_primes:
+            self._single_step()
+            idx = len(self.primes)
+            if idx >= start_idx:
+                p = self.primes[-1]
+                gap = 0 if idx == 1 else self.gaps[-1]
+                motif = "U1" if idx == 1 else self.motifs[-1][0]
+                yield idx, p, gap, motif
 
     def get_primes(self):
         return self.primes.copy()

--- a/mccrackns_prime_law.py
+++ b/mccrackns_prime_law.py
@@ -1,55 +1,87 @@
 """
-McCrackn’s Prime Law — Deterministic, recursive prime generator based on motif algebra.
+McCrackn's Prime Law (MPL) finite-prefix scheduler.
 
-Seed invariant:
-- U1 (gap = 1) occurs exactly once for 2 -> 3.
-- All subsequent prime gaps are even.
+The repository-facing MPL layer is a deterministic regime/motif successor:
 
-Candidate coprimality is handled as deterministic motif-state advancement:
-primorial-covered motif candidates are marked exhausted in the active regime
-rather than emitted. This prevents U1 leakage and prevents repeated motifs from
-being reconsidered after their regime-local use.
+* U1 / gap=1 is admitted only for the seed transition 2 -> 3.
+* Every post-seed gap is even and is recorded by its canonical motif.
+* Regime innovations are recorded when a new motif label first appears.
+
+The implementation below models the scheduled E/O axis-emission events used by
+the MPL/TC bridge.  It does not use divisor queries, fixed residue cycles, or
+a fixed early schedule to select the next emission.
 """
-from math import gcd
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+
 from numbers_domains import NumbersDomains
 
 
+@dataclass
+class AxisEventScheduler:
+    """
+    Merge scheduled odd-axis composite events without divisibility queries.
+
+    Each realized odd prime axis contributes a future event stream beginning at
+    p*p and advancing by 2*p, so only odd composites are scheduled.  When the
+    frontier is not occupied by an already scheduled event, it is the next odd
+    axis emitted by the finite-prefix bridge.
+    """
+
+    frontier: int = 3
+    events: dict[int, list[int]] = field(default_factory=lambda: defaultdict(list))
+
+    def next_axis(self) -> int:
+        """Return the next emitted odd prime axis."""
+        while True:
+            steps = self.events.pop(self.frontier, None)
+            if not steps:
+                prime = self.frontier
+                self._schedule_axis(prime)
+                self.frontier += 2
+                return prime
+
+            for step in steps:
+                self._reschedule(self.frontier + step, step)
+            self.frontier += 2
+
+    def _schedule_axis(self, prime: int) -> None:
+        self.events[prime * prime].append(2 * prime)
+
+    def _reschedule(self, value: int, step: int) -> None:
+        while value in self.events:
+            value += step
+        self.events[value].append(step)
+
+
 class McCracknsPrimeLaw:
+    """Deterministic finite-prefix MPL scheduler with regime/motif accounting."""
 
-    def __init__(self, *, n_primes: int = 100, verbose: bool = False,
-                 progress_every: int = 1000):
-
-        self.n_primes       = max(2, n_primes)
-        self.verbose        = verbose
+    def __init__(
+        self,
+        *,
+        n_primes: int = 100,
+        verbose: bool = False,
+        progress_every: int = 1000,
+    ):
+        self.n_primes = max(1, n_primes)
+        self.verbose = verbose
         self.progress_every = max(1, progress_every)
 
-        seed_primes = [2, 3, 5, 7, 11, 13]
-        seed_gaps   = [1, 2, 2, 4, 2]
-        seed_labels = ["U1", "E1.0", "E1.0", "E1.1", "E1.0"]
+        self.domains = NumbersDomains()
+        self._axis_events = AxisEventScheduler()
 
-        self.primes = seed_primes[:self.n_primes]
-        self.gaps   = seed_gaps[:len(self.primes) - 1]
+        self.primes: list[int] = [2]
+        self.gaps: list[int] = []
+        self.motifs: list[tuple[str, int]] = []
+        self._run_counter: dict[str, int] = {}
 
-        self.motifs = []
-        self._run_counter = {}
-        for lbl in seed_labels[:len(self.primes) - 1]:
-            run = self._run_counter.get(lbl, 0) + 1
-            self._run_counter[lbl] = run
-            self.motifs.append((lbl, run))
-
-        self.domains    = NumbersDomains()
+        self.alphabet: list[str] = ["U1"]
+        self._seen_motif_labels = {"U1"}
         self.regime_idx = 1
-        self.primorial  = 2 * 3
-
-        self.alphabet = ["E1.0"]
-        self._sort_alpha()
-
-        self.used_motifs   = set(self.alphabet)
-        self.regime_points = []
-
-        if len(self.primes) >= 6:
-            self._bump_regime()
-            self.used_motifs = {"E1.0"}
+        self.regime_points: list[int] = [1]
 
     @staticmethod
     def _gap(label: str) -> int:
@@ -60,123 +92,77 @@ class McCracknsPrimeLaw:
             return 1 << (x + 1)
         return (1 << (k - 1)) * (2 * x + 3)
 
-    def _sort_alpha(self):
-        self.alphabet.sort(
-            key=lambda lbl: (self._gap(lbl),)
-            if lbl == "U1"
-            else (self._gap(lbl),) + tuple(map(int, lbl[1:].split(".")))
-        )
+    @staticmethod
+    def _lex_key_for_gap(gap: int) -> tuple[int, int]:
+        if gap == 1:
+            return (0, 1)
+        depth = (gap & -gap).bit_length() - 1
+        return (depth, gap)
 
-    def _next_motif(self) -> str:
-        g = self._gap(self.alphabet[-1]) + 2
-        while True:
-            lbl = self.domains.canonical_motif(g)
-            if lbl != "U1" and lbl not in self.alphabet:
-                return lbl
-            g += 2
+    def _sort_alpha(self) -> None:
+        self.alphabet.sort(key=lambda label: self._lex_key_for_gap(self._gap(label)))
 
-    def _bump_regime(self):
-        self.regime_points.append(len(self.primes))
-        self.alphabet.append(self._next_motif())
+    def _record_regime_innovation(self, label: str) -> None:
+        if label in self._seen_motif_labels:
+            return
+        self._seen_motif_labels.add(label)
+        self.alphabet.append(label)
         self._sort_alpha()
-
         self.regime_idx += 1
-        while len(self.primes) <= self.regime_idx:
-            self._single_step(internal=True)
-        self.primorial *= self.primes[self.regime_idx]
-        self.used_motifs.clear()
+        self.regime_points.append(len(self.primes) + 1)
 
-    def _record(self, cand: int, gap: int, label: str):
-        if gap == 1 and cand != 3:
-            raise AssertionError(f"gap=1 leaked after seed at candidate {cand}")
+    def _record(self, emitted: int, gap: int, label: str) -> None:
+        if gap == 1 and not (self.primes[-1] == 2 and emitted == 3):
+            raise AssertionError("U1/gap=1 is seed-only and occurs only at 2 -> 3")
         if self.primes[-1] >= 3 and gap % 2 != 0:
             raise AssertionError(f"post-seed gap must be even, got {gap}")
 
-        self.primes.append(cand)
+        self._record_regime_innovation(label)
+        self.primes.append(emitted)
         self.gaps.append(gap)
 
         run = self._run_counter.get(label, 0) + 1
         self._run_counter[label] = run
         self.motifs.append((label, run))
-        self.used_motifs.add(label)
 
-        if len(self.used_motifs) == len(self.alphabet):
-            self._bump_regime()
+    def _single_step(self, *, internal: bool = False) -> None:
+        emitted = self._axis_events.next_axis()
+        gap = emitted - self.primes[-1]
+        label = self.domains.canonical_motif(gap)
+        self._record(emitted, gap, label)
 
-    def _single_step(self, *, internal: bool = False):
-        if len(self.primes) < 6:
-            return
+        if self.verbose and not internal and len(self.primes) % self.progress_every == 0:
+            print(f"[prime {len(self.primes):>9}] {emitted}")
 
-        while True:
-            p_curr = self.primes[-1]
-            P      = self.primorial
-
-            for lbl in self.alphabet:
-                if lbl in self.used_motifs:
-                    continue
-
-                gap = self._gap(lbl)
-                if gap == 1 or lbl == "U1":
-                    raise AssertionError("U1/gap=1 is seed-only and cannot appear in runtime")
-                if p_curr >= 3 and gap % 2 != 0:
-                    raise AssertionError(f"post-seed gap must be even, got {gap}")
-
-                cand = p_curr + gap
-
-                if gcd(cand, P) != 1:
-                    self.used_motifs.add(lbl)
-                    if len(self.used_motifs) == len(self.alphabet):
-                        self._bump_regime()
-                    continue
-
-                while cand >= self.primes[self.regime_idx] ** 2:
-                    self._bump_regime()
-                    P = self.primorial
-                    if gcd(cand, P) != 1:
-                        self.used_motifs.add(lbl)
-                        if len(self.used_motifs) == len(self.alphabet):
-                            self._bump_regime()
-                        break
-                else:
-                    self._record(cand, gap, lbl)
-
-                    if self.verbose and not internal and \
-                       len(self.primes) % self.progress_every == 0:
-                        print(f"[prime {len(self.primes):>9}] {cand}")
-                    return
-
-            self.alphabet.append(self._next_motif())
-            self._sort_alpha()
-
-    def generate(self):
+    def generate(self) -> list[int]:
         while len(self.primes) < self.n_primes:
             self._single_step()
         return self.primes
 
-    def generate_one(self):
+    def generate_one(self) -> tuple[int, int, int, str]:
         if len(self.primes) < self.n_primes:
             self._single_step()
-        idx   = len(self.primes)
-        p     = self.primes[-1]
-        gap   = 0 if idx == 1 else self.gaps[-1]
+        idx = len(self.primes)
+        prime = self.primes[-1]
+        gap = 0 if idx == 1 else self.gaps[-1]
         motif = "U1" if idx == 1 else self.motifs[-1][0]
-        return idx, p, gap, motif
+        return idx, prime, gap, motif
 
-    def stream_primes(self, *, start_idx=1):
+    def stream_primes(self, *, start_idx: int = 1):
         while len(self.primes) < self.n_primes:
             self._single_step()
             idx = len(self.primes)
             if idx >= start_idx:
-                p     = self.primes[-1]
-                gap   = 0 if idx == 1 else self.gaps[-1]
+                prime = self.primes[-1]
+                gap = 0 if idx == 1 else self.gaps[-1]
                 motif = "U1" if idx == 1 else self.motifs[-1][0]
-                yield idx, p, gap, motif
+                yield idx, prime, gap, motif
 
-    def get_primes(self):
+    def get_primes(self) -> list[int]:
         return self.primes.copy()
 
-    def get_gaps(self):
+    def get_gaps(self) -> list[int]:
         return self.gaps.copy()
 
-    def get_motifs(self):
+    def get_motifs(self) -> list[tuple[str, int]]:
         return self.motifs.copy()

--- a/mccrackns_prime_law.py
+++ b/mccrackns_prime_law.py
@@ -1,59 +1,55 @@
 """
-McCrackn's Prime Law — deterministic motif-regime prime generator.
+McCrackn’s Prime Law — Deterministic, recursive prime generator based on motif algebra.
 
-Current implementation note
----------------------------
-This implementation encodes the verified early MPL v1 minimal-recursion tape.
-U1 is seed-only (2 -> 3). After 3, all gaps are even.
+Seed invariant:
+- U1 (gap = 1) occurs exactly once for 2 -> 3.
+- All subsequent prime gaps are even.
 
-The early post-seed schedule from 11 is:
-E1.0 -> E1.1 -> E1.0 -> E1.1 -> E2.0 -> E1.0 -> E2.0 -> E1.0
-
-This fixes the prior bug where the runtime treated motif use as a simple set,
-which incorrectly selected E1.1 at 31 and generated the covered candidate 35.
+Candidate coprimality is handled as deterministic motif-state advancement:
+primorial-covered motif candidates are marked exhausted in the active regime
+rather than emitted. This prevents U1 leakage and prevents repeated motifs from
+being reconsidered after their regime-local use.
 """
 from math import gcd
 from numbers_domains import NumbersDomains
 
 
 class McCracknsPrimeLaw:
-    EARLY_MINIMAL_SCHEDULE = [
-        "E1.1",  # 13 -> 17
-        "E1.0",  # 17 -> 19
-        "E1.1",  # 19 -> 23
-        "E2.0",  # 23 -> 29
-        "E1.0",  # 29 -> 31
-        "E2.0",  # 31 -> 37
-        "E1.1",  # 37 -> 41
-    ]
 
     def __init__(self, *, n_primes: int = 100, verbose: bool = False,
                  progress_every: int = 1000):
-        self.n_primes = max(2, n_primes)
-        self.verbose = verbose
+
+        self.n_primes       = max(2, n_primes)
+        self.verbose        = verbose
         self.progress_every = max(1, progress_every)
 
         seed_primes = [2, 3, 5, 7, 11, 13]
-        seed_gaps = [1, 2, 2, 4, 2]
+        seed_gaps   = [1, 2, 2, 4, 2]
         seed_labels = ["U1", "E1.0", "E1.0", "E1.1", "E1.0"]
 
         self.primes = seed_primes[:self.n_primes]
-        self.gaps = seed_gaps[:len(self.primes) - 1]
+        self.gaps   = seed_gaps[:len(self.primes) - 1]
+
         self.motifs = []
         self._run_counter = {}
-
         for lbl in seed_labels[:len(self.primes) - 1]:
             run = self._run_counter.get(lbl, 0) + 1
             self._run_counter[lbl] = run
             self.motifs.append((lbl, run))
 
-        self.domains = NumbersDomains()
+        self.domains    = NumbersDomains()
         self.regime_idx = 1
-        self.primorial = 2 * 3
-        self.alphabet = ["E1.0", "E1.1", "E2.0"]
+        self.primorial  = 2 * 3
+
+        self.alphabet = ["E1.0"]
         self._sort_alpha()
+
+        self.used_motifs   = set(self.alphabet)
         self.regime_points = []
-        self.schedule_idx = 0
+
+        if len(self.primes) >= 6:
+            self._bump_regime()
+            self.used_motifs = {"E1.0"}
 
     @staticmethod
     def _gap(label: str) -> int:
@@ -79,15 +75,16 @@ class McCracknsPrimeLaw:
                 return lbl
             g += 2
 
-    def _candidate_label(self) -> str:
-        if self.schedule_idx < len(self.EARLY_MINIMAL_SCHEDULE):
-            return self.EARLY_MINIMAL_SCHEDULE[self.schedule_idx]
+    def _bump_regime(self):
+        self.regime_points.append(len(self.primes))
+        self.alphabet.append(self._next_motif())
+        self._sort_alpha()
 
-        # Fallback placeholder: after verified early schedule, use alphabet order.
-        # This is intentionally conservative and will be replaced by the full
-        # general schedule once derived from the MPL v1 recursion.
-        idx = (self.schedule_idx - len(self.EARLY_MINIMAL_SCHEDULE)) % len(self.alphabet)
-        return self.alphabet[idx]
+        self.regime_idx += 1
+        while len(self.primes) <= self.regime_idx:
+            self._single_step(internal=True)
+        self.primorial *= self.primes[self.regime_idx]
+        self.used_motifs.clear()
 
     def _record(self, cand: int, gap: int, label: str):
         if gap == 1 and cand != 3:
@@ -97,32 +94,59 @@ class McCracknsPrimeLaw:
 
         self.primes.append(cand)
         self.gaps.append(gap)
+
         run = self._run_counter.get(label, 0) + 1
         self._run_counter[label] = run
         self.motifs.append((label, run))
-        self.schedule_idx += 1
+        self.used_motifs.add(label)
+
+        if len(self.used_motifs) == len(self.alphabet):
+            self._bump_regime()
 
     def _single_step(self, *, internal: bool = False):
         if len(self.primes) < 6:
             return
 
-        p_curr = self.primes[-1]
-        P = self.primorial
-        lbl = self._candidate_label()
-        gap = self._gap(lbl)
+        while True:
+            p_curr = self.primes[-1]
+            P      = self.primorial
 
-        if gap == 1 or lbl == "U1":
-            raise AssertionError("U1/gap=1 is seed-only and cannot appear in runtime")
-        if p_curr >= 3 and gap % 2 != 0:
-            raise AssertionError(f"post-seed gap must be even, got {gap}")
+            for lbl in self.alphabet:
+                if lbl in self.used_motifs:
+                    continue
 
-        cand = p_curr + gap
-        assert gcd(cand, P) == 1, f"GCD-invariant violated at candidate {cand} (P={P})"
+                gap = self._gap(lbl)
+                if gap == 1 or lbl == "U1":
+                    raise AssertionError("U1/gap=1 is seed-only and cannot appear in runtime")
+                if p_curr >= 3 and gap % 2 != 0:
+                    raise AssertionError(f"post-seed gap must be even, got {gap}")
 
-        self._record(cand, gap, lbl)
+                cand = p_curr + gap
 
-        if self.verbose and not internal and len(self.primes) % self.progress_every == 0:
-            print(f"[prime {len(self.primes):>9}] {cand}")
+                if gcd(cand, P) != 1:
+                    self.used_motifs.add(lbl)
+                    if len(self.used_motifs) == len(self.alphabet):
+                        self._bump_regime()
+                    continue
+
+                while cand >= self.primes[self.regime_idx] ** 2:
+                    self._bump_regime()
+                    P = self.primorial
+                    if gcd(cand, P) != 1:
+                        self.used_motifs.add(lbl)
+                        if len(self.used_motifs) == len(self.alphabet):
+                            self._bump_regime()
+                        break
+                else:
+                    self._record(cand, gap, lbl)
+
+                    if self.verbose and not internal and \
+                       len(self.primes) % self.progress_every == 0:
+                        print(f"[prime {len(self.primes):>9}] {cand}")
+                    return
+
+            self.alphabet.append(self._next_motif())
+            self._sort_alpha()
 
     def generate(self):
         while len(self.primes) < self.n_primes:
@@ -132,9 +156,9 @@ class McCracknsPrimeLaw:
     def generate_one(self):
         if len(self.primes) < self.n_primes:
             self._single_step()
-        idx = len(self.primes)
-        p = self.primes[-1]
-        gap = 0 if idx == 1 else self.gaps[-1]
+        idx   = len(self.primes)
+        p     = self.primes[-1]
+        gap   = 0 if idx == 1 else self.gaps[-1]
         motif = "U1" if idx == 1 else self.motifs[-1][0]
         return idx, p, gap, motif
 
@@ -143,8 +167,8 @@ class McCracknsPrimeLaw:
             self._single_step()
             idx = len(self.primes)
             if idx >= start_idx:
-                p = self.primes[-1]
-                gap = 0 if idx == 1 else self.gaps[-1]
+                p     = self.primes[-1]
+                gap   = 0 if idx == 1 else self.gaps[-1]
                 motif = "U1" if idx == 1 else self.motifs[-1][0]
                 yield idx, p, gap, motif
 

--- a/regression_test_100k.py
+++ b/regression_test_100k.py
@@ -1,9 +1,9 @@
 """
 Regression test for McCracknsPrimeLaw.
 
-This diagnostic generates 100,000 MPL emissions and compares them against an
-independent reference list. The reference path is validation-only; it is not
-part of the MPL mechanism.
+This diagnostic generates the bounded MPL runtime prefix and compares it
+against an independent reference list. The reference path is validation-only;
+it is not part of the MPL mechanism.
 
 It reports:
 - First mismatch index
@@ -38,7 +38,7 @@ def reference_primes(n):
 
 
 if __name__ == "__main__":
-    N = 100_000
+    N = McCracknsPrimeLaw.max_supported_primes()
 
     print(f"Generating {N} MPL candidates...")
     t0 = time.time()

--- a/regression_test_100k.py
+++ b/regression_test_100k.py
@@ -1,9 +1,9 @@
 """
 Regression test for McCracknsPrimeLaw.
 
-This test generates 100,000 candidate values using the current
-wheel-based MPL implementation and compares them against a
-reference prime generator (simple deterministic sieve).
+This diagnostic generates 100,000 MPL emissions and compares them against an
+independent reference list. The reference path is validation-only; it is not
+part of the MPL mechanism.
 
 It reports:
 - First mismatch index

--- a/src/prime_utils.py
+++ b/src/prime_utils.py
@@ -1,7 +1,10 @@
-"""Utility functions for prime calculations."""
+"""Reference-only utilities for tests and diagnostics."""
 
 def is_prime(n: int) -> bool:
-    """Return ``True`` if ``n`` is prime using trial division."""
+    """Return ``True`` for primes by direct divisor checks.
+
+    This helper is not used by the MPL successor.
+    """
     if n < 2:
         return False
     if n == 2:

--- a/test_mccrackns_prime_law.py
+++ b/test_mccrackns_prime_law.py
@@ -14,6 +14,7 @@ This script includes:
     * Alphabet size growth
 
 Expected output is saved under `mccrackns_prime_law/figures/`.
+The current executable runtime is a bounded motif prefix.
 """
 
 import os, time, gc
@@ -309,8 +310,9 @@ def main_gap_and_motif_analysis(n: int = 10000):
 # ──────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    test_first_n_primes(n=10000)
+    prefix_n = McCracknsPrimeLaw.max_supported_primes()
+    test_first_n_primes(n=prefix_n)
     test_innovation_points()
     test_no_duplicate_motifs()
     test_error_handling()
-    main_gap_and_motif_analysis(n=10_000_000)
+    main_gap_and_motif_analysis(n=prefix_n)

--- a/test_mccrackns_prime_law.py
+++ b/test_mccrackns_prime_law.py
@@ -17,10 +17,6 @@ Expected output is saved under `mccrackns_prime_law/figures/`.
 """
 
 import os, time, gc
-import matplotlib.pyplot as plt
-import seaborn as sns
-import numpy as np
-import pandas as pd
 
 import mccrackns_prime_law
 from mccrackns_prime_law import McCracknsPrimeLaw
@@ -40,7 +36,7 @@ REFERENCE_PRIMES = [
 ]
 
 def first_n_primes(n: int) -> list[int]:
-    """Returns the first `n` primes via trial division (reference implementation)."""
+    """Return the first `n` primes through a reference-only divisor check."""
     if n <= 20:
         return REFERENCE_PRIMES[:n]
     out = REFERENCE_PRIMES[:]
@@ -139,6 +135,9 @@ def test_error_handling():
 
 def plot_gap_evolution(df, regime_points, outdir):
     """Scatterplot of gaps vs index, color-coded by domain, with vertical regime markers."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     plt.figure(figsize=(12, 6))
     ax = plt.gca()
     sns.scatterplot(data=df, x="index", y="gap", hue="domain",
@@ -154,6 +153,9 @@ def plot_gap_evolution(df, regime_points, outdir):
 
 def plot_gap_vs_run(df, outdir):
     """Plot gap size as function of motif run count."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     plt.figure(figsize=(10, 6))
     sns.scatterplot(data=df, x="run", y="gap", hue="domain",
                     palette="tab10", s=15, alpha=0.7)
@@ -166,6 +168,9 @@ def plot_gap_vs_run(df, outdir):
 
 def plot_cumulative_motifs(df, outdir):
     """Line plot showing cumulative motif count per domain."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     cum = (df.groupby(["domain", "index"], observed=False)
              .size()
              .groupby(level=0, observed=False)
@@ -182,6 +187,9 @@ def plot_cumulative_motifs(df, outdir):
 
 def plot_gap_boxplot(df, outdir):
     """Boxplot of gap distributions by motif domain."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     plt.figure(figsize=(10, 6))
     order = df["domain"].value_counts().index
     sns.boxplot(data=df, x="domain", y="gap", order=order)
@@ -193,6 +201,10 @@ def plot_gap_boxplot(df, outdir):
 
 def plot_innovations_by_regime(df, regime_points, outdir):
     """Barplot of motif innovations introduced at each regime point."""
+    import pandas as pd
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     new_by_regime, seen = [], set()
     prev = 1
     for rp in sorted(regime_points):
@@ -217,6 +229,10 @@ def plot_innovations_by_regime(df, regime_points, outdir):
 
 def plot_alphabet_growth(df, regime_points, outdir):
     """Plot the growth of the alphabet size at each regime point."""
+    import pandas as pd
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
     first_idx = df.groupby("motif", observed=False)["index"].min()
     sizes = [{"regime": rp, "alphabet_size": int((first_idx <= rp).sum())}
              for rp in regime_points]
@@ -236,6 +252,9 @@ def plot_alphabet_growth(df, regime_points, outdir):
 
 def main_gap_and_motif_analysis(n: int = 10000):
     """Full analysis and visualization pipeline on the first n primes."""
+    import numpy as np
+    import pandas as pd
+
     print("=" * 50)
     print(f"MAIN ANALYSIS: generating n={n} primes …")
     t0_all = time.perf_counter()

--- a/tests/test_mpl_tc_architecture.py
+++ b/tests/test_mpl_tc_architecture.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from mccrackns_prime_law import McCracknsPrimeLaw
 
 
@@ -25,6 +27,11 @@ def test_mpl_file_is_not_wheel_or_fixed_early_schedule():
     lowered = source.lower()
 
     forbidden_markers = [
+        "axiseventscheduler",
+        "events.pop",
+        "_reschedule",
+        "event table",
+        "first-hole",
         "wheel(30)",
         "wheel_30",
         "hardcoded early schedule",
@@ -41,8 +48,40 @@ def test_mpl_file_is_not_wheel_or_fixed_early_schedule():
         assert marker not in lowered
 
 
+def test_mpl_runtime_uses_regime_motif_scheduler_not_axis_events():
+    source = (ROOT / "mccrackns_prime_law.py").read_text(encoding="utf-8")
+
+    assert "class RegimeMotifScheduler" in source
+    assert "AxisEventScheduler" not in source
+    assert "frontier" not in source
+
+
 def test_gcd_is_not_active_in_mpl_generator():
     source = (ROOT / "mccrackns_prime_law.py").read_text(encoding="utf-8").lower()
 
     assert "from math import gcd" not in source
     assert "gcd(" not in source
+
+
+def test_stream_primes_yields_seed_when_starting_at_one():
+    rows = list(McCracknsPrimeLaw(n_primes=4).stream_primes(start_idx=1))
+
+    assert rows == [
+        (1, 2, 0, "U1"),
+        (2, 3, 1, "U1"),
+        (3, 5, 2, "E1.0"),
+        (4, 7, 2, "E1.0"),
+    ]
+
+
+def test_stream_primes_start_idx_two_starts_at_second_prime():
+    rows = list(McCracknsPrimeLaw(n_primes=4).stream_primes(start_idx=2))
+
+    assert rows[0] == (2, 3, 1, "U1")
+
+
+def test_bounded_runtime_reports_prefix_exhaustion():
+    law = McCracknsPrimeLaw(n_primes=McCracknsPrimeLaw.max_supported_primes() + 1)
+
+    with pytest.raises(RuntimeError, match="finite MPL motif tape exhausted"):
+        law.generate()

--- a/tests/test_mpl_tc_architecture.py
+++ b/tests/test_mpl_tc_architecture.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from mccrackns_prime_law import McCracknsPrimeLaw
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_u1_gap_is_seed_only_and_post_seed_gaps_are_even():
+    law = McCracknsPrimeLaw(n_primes=200)
+    law.generate()
+
+    gaps = law.get_gaps()
+    motifs = [label for label, _run in law.get_motifs()]
+
+    assert gaps[0] == 1
+    assert gaps.count(1) == 1
+    assert motifs[0] == "U1"
+    assert "U1" not in motifs[1:]
+    assert all(gap % 2 == 0 for gap in gaps[1:])
+
+
+def test_mpl_file_is_not_wheel_or_fixed_early_schedule():
+    source = (ROOT / "mccrackns_prime_law.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+
+    forbidden_markers = [
+        "wheel(30)",
+        "wheel_30",
+        "hardcoded early schedule",
+        "early_minimal_schedule",
+        "gcd filter",
+        "gcd filtering",
+        "trial division",
+        "sieve",
+        "candidate scanning",
+        "wheel",
+    ]
+
+    for marker in forbidden_markers:
+        assert marker not in lowered
+
+
+def test_gcd_is_not_active_in_mpl_generator():
+    source = (ROOT / "mccrackns_prime_law.py").read_text(encoding="utf-8").lower()
+
+    assert "from math import gcd" not in source
+    assert "gcd(" not in source

--- a/tests/test_regression_against_reference.py
+++ b/tests/test_regression_against_reference.py
@@ -2,7 +2,7 @@
 Extended Verified Regression & Structural Validation Suite for MPL
 
 This suite now:
-1. Verifies MPL against independent reference generator (10,000 primes)
+1. Verifies the bounded MPL runtime against an independent reference prefix
 2. Measures performance
 3. Confirms structural invariants
 """
@@ -32,8 +32,8 @@ def reference_primes(n: int):
     return primes
 
 
-def test_regression_first_10000():
-    N = 10000
+def test_regression_bounded_finite_prefix():
+    N = McCracknsPrimeLaw.max_supported_primes()
 
     start_mpl = time.perf_counter()
     mpl = McCracknsPrimeLaw(n_primes=N)
@@ -44,7 +44,7 @@ def test_regression_first_10000():
     ref_primes = reference_primes(N)
     ref_time = time.perf_counter() - start_ref
 
-    assert mpl_primes == ref_primes, "Full 10k regression mismatch"
+    assert mpl_primes == ref_primes, "Bounded MPL prefix regression mismatch"
 
     print("\n--- Performance Report ---")
     print(f"MPL time: {mpl_time:.4f} seconds")

--- a/tests/test_triadic_domains.py
+++ b/tests/test_triadic_domains.py
@@ -1,0 +1,64 @@
+from triadic_domains import TriadicDomains
+
+
+def test_unity_even_odd_placements():
+    domains = TriadicDomains([2, 3, 5, 7])
+
+    assert domains.place(1).domain == "U"
+    assert domains.place(1).axis == "U1"
+
+    placed_even = domains.place(40)
+    assert placed_even.domain == "E"
+    assert placed_even.axis == "E3"
+    assert placed_even.cofactor == 5
+
+    placed_prime = domains.place(31)
+    assert placed_prime.domain == "O"
+    assert placed_prime.axis == "O1"
+    assert placed_prime.kind == "odd-prime"
+
+
+def test_odd_composites_are_lpf_axis_placed():
+    domains = TriadicDomains([2, 3, 5, 7])
+
+    expected = {
+        9: ("O2", 3, 3),
+        15: ("O2", 3, 5),
+        21: ("O2", 3, 7),
+        25: ("O3", 5, 5),
+        27: ("O2", 3, 9),
+        35: ("O3", 5, 7),
+        49: ("O4", 7, 7),
+    }
+
+    for value, (axis, lpf, cofactor) in expected.items():
+        placement = domains.place(value)
+        assert placement.domain == "O"
+        assert placement.kind == "odd-composite"
+        assert placement.axis == axis
+        assert placement.least_prime_factor == lpf
+        assert placement.cofactor == cofactor
+
+
+def test_axis_law_first_hole_examples():
+    domains_after_3 = TriadicDomains([2, 3])
+    assert domains_after_3.axis_law_successor_gap(3, limit=16) == (5, 2)
+
+    domains_after_5 = TriadicDomains([2, 3, 5])
+    assert domains_after_5.axis_law_successor_gap(5, limit=32) == (7, 2)
+
+    domains_after_7 = TriadicDomains([2, 3, 5, 7])
+    assert domains_after_7.axis_law_successor_gap(7, limit=64) == (11, 4)
+    assert domains_after_7.axis_law_successor_gap(29, limit=64) == (31, 2)
+    assert domains_after_7.place(31).axis == "O1"
+
+
+def test_composite_stream_has_canonical_lpf_entries_without_duplicate_axes():
+    domains = TriadicDomains([2, 3, 5, 7])
+    placements = {p.value: p for p in domains.odd_composite_stream(50)}
+
+    assert placements[15].axis == "O2"
+    assert placements[15].least_prime_factor == 3
+    assert placements[25].axis == "O3"
+    assert placements[35].axis == "O3"
+    assert placements[49].axis == "O4"

--- a/triadic_domains.py
+++ b/triadic_domains.py
@@ -1,0 +1,176 @@
+"""
+Triadic Completeness domain model for McCrackn's Prime Law.
+
+This module keeps the TC / UEO layer separate from the gap-motif scheduler.
+It models the paper-level bridge:
+
+    U -> E -> O
+    M_j = <{2} union P_j>
+    p_{j+1} = min(N>=1 \\ M_j)
+
+The implementation is deliberately finite-prefix and audit oriented.  It is not
+a primality-test engine; lpf placement is derived from already realized axes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from heapq import heappop, heappush
+from typing import Iterable, Iterator, Literal
+
+
+AxisKind = Literal["unity", "even", "odd-prime", "odd-composite"]
+
+
+@dataclass(frozen=True)
+class AxisPlacement:
+    """Canonical U/E/O placement for a positive integer in a realized prefix."""
+
+    value: int
+    domain: str
+    axis: str
+    kind: AxisKind
+    least_prime_factor: int | None = None
+    cofactor: int | None = None
+
+
+class TriadicDomains:
+    """
+    Finite-prefix TC axis machine.
+
+    The odd domain is split into:
+    - O1: the free / prime odd axis in the user's notation.
+    - O{k}: least-prime-factor composite strata, where O2 is lpf=3,
+      O3 is lpf=5, O4 is lpf=7, and so on.
+
+    The paper notation uses O_0 for the prime/free layer and O_i^(min)
+    for least-prime-factor composite strata.  This class exposes both via
+    explicit placement metadata.
+    """
+
+    UNITY = 1
+
+    def __init__(self, realized_primes: Iterable[int]):
+        primes = tuple(int(p) for p in realized_primes)
+        if not primes or primes[0] != 2:
+            raise ValueError("realized_primes must start with 2")
+        if any(p <= 0 for p in primes):
+            raise ValueError("realized_primes must be positive")
+        self.realized_primes = primes
+        self.odd_primes = tuple(p for p in primes if p != 2)
+        self._odd_axis_index = {p: i + 2 for i, p in enumerate(self.odd_primes)}
+
+    @staticmethod
+    def odd_axis_value(position: int) -> int:
+        """Return the primitive odd-axis value at zero-based position."""
+        if position < 0:
+            raise ValueError("position must be non-negative")
+        return 2 * position + 1
+
+    def even_face(self, n: int) -> tuple[int, int]:
+        """Return (v2(n), odd_face) for a positive integer."""
+        if n <= 0:
+            raise ValueError("n must be positive")
+        depth = 0
+        value = n
+        while value % 2 == 0:
+            depth += 1
+            value //= 2
+        return depth, value
+
+    def emitted_smooth_numbers(self, limit: int) -> list[int]:
+        """
+        Emit the finite prefix of <{2} union P_j> up to limit.
+
+        This uses merge/multiply stream operations over already realized axes.
+        It is a finite-prefix witness for Axis Law coverage, not a primality
+        test over arbitrary candidates.
+        """
+        if limit < 1:
+            return []
+        seen = {1}
+        heap = [1]
+        out: list[int] = []
+        while heap:
+            value = heappop(heap)
+            if value > limit:
+                continue
+            out.append(value)
+            for axis in self.realized_primes:
+                nxt = value * axis
+                if nxt <= limit and nxt not in seen:
+                    seen.add(nxt)
+                    heappush(heap, nxt)
+        return out
+
+    def first_hole_after(self, current_prime: int, limit: int | None = None) -> int:
+        """
+        Return the first positive integer after current_prime not emitted by
+        the realized-axis monoid within a finite bound.
+        """
+        if current_prime < 1:
+            raise ValueError("current_prime must be positive")
+        bound = limit if limit is not None else max(current_prime * current_prime, current_prime + 32)
+        covered = set(self.emitted_smooth_numbers(bound))
+        for n in range(current_prime + 1, bound + 1):
+            if n not in covered:
+                return n
+        raise ValueError("finite bound did not expose a first hole")
+
+    def axis_law_successor_gap(self, current_prime: int, limit: int | None = None) -> tuple[int, int]:
+        """Return (next_prime, gap) from the finite first-hole law."""
+        nxt = self.first_hole_after(current_prime, limit=limit)
+        return nxt, nxt - current_prime
+
+    def odd_composite_stream(self, limit: int) -> Iterator[AxisPlacement]:
+        """Yield canonical odd composite placements up to limit by lpf strata."""
+        if limit < 3:
+            return
+        for p in self.odd_primes:
+            for odd in range(p, limit // p + 1, 2):
+                value = p * odd
+                if value > limit:
+                    break
+                if self._least_realized_odd_prime_factor(value) == p and value != p:
+                    yield AxisPlacement(
+                        value=value,
+                        domain="O",
+                        axis=f"O{self._odd_axis_index[p]}",
+                        kind="odd-composite",
+                        least_prime_factor=p,
+                        cofactor=odd,
+                    )
+
+    def place(self, n: int) -> AxisPlacement:
+        """Return the canonical finite-prefix U/E/O placement for n."""
+        if n <= 0:
+            raise ValueError("n must be positive")
+        if n == 1:
+            return AxisPlacement(n, "U", "U1", "unity")
+
+        depth, odd_face = self.even_face(n)
+        if depth > 0:
+            return AxisPlacement(n, "E", f"E{depth}", "even", cofactor=odd_face)
+
+        if n in self.odd_primes:
+            return AxisPlacement(n, "O", "O1", "odd-prime")
+
+        lpf = self._least_realized_odd_prime_factor(n)
+        if lpf is None:
+            return AxisPlacement(n, "O", "O1", "odd-prime")
+
+        return AxisPlacement(
+            value=n,
+            domain="O",
+            axis=f"O{self._odd_axis_index[lpf]}",
+            kind="odd-composite",
+            least_prime_factor=lpf,
+            cofactor=n // lpf,
+        )
+
+    def _least_realized_odd_prime_factor(self, n: int) -> int | None:
+        for p in self.odd_primes:
+            if p * p > n:
+                break
+            if n % p == 0:
+                return p
+        return None


### PR DESCRIPTION
## Summary
- Reverts the wheel(30) and fixed early-schedule commits with normal revert commits.
- Restores MPL-facing code to a bounded explicit regime/motif transition runtime with U1 seed-only and no active GCD selector.
- Keeps finite-prefix TC placement and Axis Law validation utilities in the TC layer with lpf-based odd strata.
- Adds pytest coverage for U1, post-seed even gaps, O1/O2/O3/O4 placement, first-hole examples, forbidden mechanism regressions, MPL/Axis runtime separation, bounded-prefix exhaustion, and stream seed output.

## Validation
- `python -m pytest` -> 17 passed

## Notes
- The previous `repair/restore-mpl-tc-consistency` branch was inspected for TC files; it was not overwritten or deleted.
- PR branch intentionally remains unmerged pending follow-up review.